### PR TITLE
Remove 'Beckman Printing' tab

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -20,6 +20,7 @@
             <b-nav-item href="print_destination_plate_labels"
               >Print Labels</b-nav-item
             >
+            <!-- Below is commented as required Lighthouse endpoints are on hold until Beckman robot is live-->
             <!-- <b-nav-item to="beckman_cherrypick">Beckman Cherrypick</b-nav-item> -->
           </b-navbar-nav>
         </b-collapse>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -20,7 +20,7 @@
             <b-nav-item href="print_destination_plate_labels"
               >Print Labels</b-nav-item
             >
-            <b-nav-item to="beckman_cherrypick">Beckman Cherrypick</b-nav-item>
+            <!-- <b-nav-item to="beckman_cherrypick">Beckman Cherrypick</b-nav-item> -->
           </b-navbar-nav>
         </b-collapse>
       </b-navbar>

--- a/test/layouts/default.spec.js
+++ b/test/layouts/default.spec.js
@@ -24,6 +24,7 @@ describe('Index', () => {
   it('has a navbar', () => {
     expect(wrapper.findComponent({ ref: 'navbar' }).text()).toMatch(
       /Lighthouse {2}Reports Box Buster Sentinel Sample Creation Sentinel Cherrypick Imports Print Labels/
+      // /Lighthouse {2}Reports Box Buster Sentinel Sample Creation Sentinel Cherrypick Imports Print Labels Beckman Cherrypick/
     )
   })
 })


### PR DESCRIPTION
Hide new 'Beckman Cherrypick' tab
Part of migrate to prod: https://github.com/sanger/General-Backlog-Items/issues/96
