### PR TITLE
GPL-856 barcode disappears on scan 

### DIFF
--- a/pages/box_buster.vue
+++ b/pages/box_buster.vue
@@ -156,8 +156,6 @@ export default {
         // Requirements were that we should allow plate lookups
         this.findPlates({ barcodes: [this.barcode] })
       }
-      this.barcodes_scanned.push(this.barcode)
-      this.barcode = ''
     },
     reset() {
       this.labwhereResponse = defaultResponse
@@ -169,6 +167,8 @@ export default {
       this.lighthouseResponse = response
       if (response.success) {
         this.plates = response.plates || []
+        this.barcodes_scanned.push(this.barcode)
+        this.barcode = ''
       }
     }
   }

--- a/pages/box_buster.vue
+++ b/pages/box_buster.vue
@@ -148,9 +148,9 @@ export default {
         this.barcodes_scanned.indexOf(barcode) !==
         this.barcodes_scanned.lastIndexOf(barcode)
       ) {
-        return { red: true }
+        return { 'text-danger': true }
       }
-      return { red: false }
+      return { 'text-danger': false }
     },
     rowClass(item, type) {
       if (item && type === 'row') {
@@ -191,8 +191,3 @@ export default {
   }
 }
 </script>
-<style>
-.red {
-  color: red;
-}
-</style>

--- a/pages/box_buster.vue
+++ b/pages/box_buster.vue
@@ -41,7 +41,16 @@
         <span>{{ total_without_maps }} without.</span>
         <span>Total {{ total_positives }} positives.</span>
         <br />
-        <span>Box barcodes scanned: {{ barcodes_scanned.join(', ') }}</span>
+        <span>Box barcodes scanned:</span>
+        <span
+          v-for="scanned_barcode in barcodes_scanned"
+          :key="scanned_barcode"
+        >
+          <span v-if="isBarcodeDuplicate(scanned_barcode)" class="red">
+            {{ scanned_barcode }},
+          </span>
+          <span v-else>{{ scanned_barcode }}, </span>
+        </span>
       </template>
     </b-table>
   </b-container>
@@ -135,6 +144,15 @@ export default {
   },
   created() {},
   methods: {
+    isBarcodeDuplicate(barcode) {
+      if (
+        this.barcodes_scanned.indexOf(barcode) !==
+        this.barcodes_scanned.lastIndexOf(barcode)
+      ) {
+        return true
+      }
+      return false
+    },
     rowClass(item, type) {
       if (item && type === 'row') {
         return item.plate_map ? 'table-success' : 'table-danger'
@@ -174,3 +192,8 @@ export default {
   }
 }
 </script>
+<style>
+.red {
+  color: red;
+}
+</style>

--- a/pages/box_buster.vue
+++ b/pages/box_buster.vue
@@ -46,10 +46,9 @@
           v-for="scanned_barcode in barcodes_scanned"
           :key="scanned_barcode"
         >
-          <span v-if="isBarcodeDuplicate(scanned_barcode)" class="red">
+          <span :class="isBarcodeDuplicate(scanned_barcode)">
             {{ scanned_barcode }},
           </span>
-          <span v-else>{{ scanned_barcode }}, </span>
         </span>
       </template>
     </b-table>
@@ -149,9 +148,9 @@ export default {
         this.barcodes_scanned.indexOf(barcode) !==
         this.barcodes_scanned.lastIndexOf(barcode)
       ) {
-        return true
+        return { red: true }
       }
-      return false
+      return { red: false }
     },
     rowClass(item, type) {
       if (item && type === 'row') {

--- a/pages/box_buster.vue
+++ b/pages/box_buster.vue
@@ -40,6 +40,8 @@
         <span>{{ total_with_maps }} plates with plates maps,</span>
         <span>{{ total_without_maps }} without.</span>
         <span>Total {{ total_positives }} positives.</span>
+        <br />
+        <span>Box barcodes scanned: {{ barcodes_scanned.join(', ') }}</span>
       </template>
     </b-table>
   </b-container>
@@ -78,6 +80,7 @@ export default {
     return {
       barcode: '',
       plates: [],
+      barcodes_scanned: [],
       labwhereResponse: defaultResponse,
       lighthouseResponse: defaultResponse,
       fields: [
@@ -153,6 +156,8 @@ export default {
         // Requirements were that we should allow plate lookups
         this.findPlates({ barcodes: [this.barcode] })
       }
+      this.barcodes_scanned.push(this.barcode)
+      this.barcode = ''
     },
     reset() {
       this.labwhereResponse = defaultResponse

--- a/test/pages/box_buster.spec.js
+++ b/test/pages/box_buster.spec.js
@@ -4,7 +4,6 @@ import flushPromises from 'flush-promises'
 import BoxBuster from '@/pages/box_buster.vue'
 import { getPlatesFromBoxBarcodes } from '@/modules/labwhere'
 import lighthouse from '@/modules/lighthouse_service'
-import { equal } from 'assert'
 
 // Mock the whole module. Returning jest.fn() allows you to mock methods here
 // jest.mock('@/modules/labwhere', () => jest.fn())
@@ -300,5 +299,4 @@ describe('BoxBuster', () => {
     expect(wrapper.vm.barcode).toEqual('')
     expect(barcodeField.element.value).toEqual('')
   })
-
 })

--- a/test/pages/box_buster.spec.js
+++ b/test/pages/box_buster.spec.js
@@ -4,6 +4,7 @@ import flushPromises from 'flush-promises'
 import BoxBuster from '@/pages/box_buster.vue'
 import { getPlatesFromBoxBarcodes } from '@/modules/labwhere'
 import lighthouse from '@/modules/lighthouse_service'
+import { equal } from 'assert'
 
 // Mock the whole module. Returning jest.fn() allows you to mock methods here
 // jest.mock('@/modules/labwhere', () => jest.fn())
@@ -288,4 +289,16 @@ describe('BoxBuster', () => {
     await flushPromises()
     expect(getPlatesFromBoxBarcodes).not.toHaveBeenCalled()
   })
+
+  it('looks up plates in lighthouse', async () => {
+    wrapper = mount(BoxBuster, { localVue })
+    const barcodeField = wrapper.find('#box-barcode-field')
+    barcodeField.setValue('12345')
+    await barcodeField.trigger('change')
+    await flushPromises()
+    expect(wrapper.vm.barcodes_scanned).toEqual(['12345'])
+    expect(wrapper.vm.barcode).toEqual('')
+    expect(barcodeField.element.value).toEqual('')
+  })
+
 })

--- a/test/pages/box_buster.spec.js
+++ b/test/pages/box_buster.spec.js
@@ -290,11 +290,16 @@ describe('BoxBuster', () => {
   })
 
   it('looks up plates in lighthouse', async () => {
+    lighthouse.findPlatesFromBarcodes.mockResolvedValue({
+      success: true,
+      plates: examplePlates
+    })
     wrapper = mount(BoxBuster, { localVue })
     const barcodeField = wrapper.find('#box-barcode-field')
     barcodeField.setValue('12345')
     await barcodeField.trigger('change')
     await flushPromises()
+
     expect(wrapper.vm.barcodes_scanned).toEqual(['12345'])
     expect(wrapper.vm.barcode).toEqual('')
     expect(barcodeField.element.value).toEqual('')

--- a/test/pages/box_buster.spec.js
+++ b/test/pages/box_buster.spec.js
@@ -303,14 +303,13 @@ describe('BoxBuster', () => {
     expect(wrapper.vm.barcodes_scanned).toEqual(['12345'])
     expect(wrapper.vm.barcode).toEqual('')
     expect(barcodeField.element.value).toEqual('')
-    expect(wrapper.find('caption').text()).toContain('Box barcodes scanned: 12345')
+    expect(wrapper.find('caption').text()).toContain('12345')
   })
 
-  it('checks if the scanned barcodes are duplicates', async () => {
+  it('checks if the scanned barcodes are duplicates', () => {
     wrapper = mount(BoxBuster, { localVue })
     wrapper.vm.barcodes_scanned = ['12345', '12345', 'barcode']
-    expect(wrapper.vm.isBarcodeDuplicate('12345')).toBe(true)
-    expect(wrapper.vm.isBarcodeDuplicate('barcode')).toBe(false)
+    expect(wrapper.vm.isBarcodeDuplicate('12345')).toEqual({ red: true })
+    expect(wrapper.vm.isBarcodeDuplicate('barcode')).toEqual({ red: false })
   })
-
 })

--- a/test/pages/box_buster.spec.js
+++ b/test/pages/box_buster.spec.js
@@ -289,7 +289,7 @@ describe('BoxBuster', () => {
     expect(getPlatesFromBoxBarcodes).not.toHaveBeenCalled()
   })
 
-  it('looks up plates in lighthouse', async () => {
+  it('will clear the barcode field after a barcode is entered', async () => {
     lighthouse.findPlatesFromBarcodes.mockResolvedValue({
       success: true,
       plates: examplePlates
@@ -305,4 +305,12 @@ describe('BoxBuster', () => {
     expect(barcodeField.element.value).toEqual('')
     expect(wrapper.find('caption').text()).toContain('Box barcodes scanned: 12345')
   })
+
+  it('checks if the scanned barcodes are duplicates', async () => {
+    wrapper = mount(BoxBuster, { localVue })
+    wrapper.vm.barcodes_scanned = ['12345', '12345', 'barcode']
+    expect(wrapper.vm.isBarcodeDuplicate('12345')).toBe(true)
+    expect(wrapper.vm.isBarcodeDuplicate('barcode')).toBe(false)
+  })
+
 })

--- a/test/pages/box_buster.spec.js
+++ b/test/pages/box_buster.spec.js
@@ -107,7 +107,8 @@ describe('BoxBuster', () => {
     const expected = squish(`Box Summary: Total of ${expectedPlateTotal} plates in box;
     ${expectedMapTotal} plates with plates maps,
     ${expectedMaplessTotal} without.
-    Total ${expectedPositiveTotal} positives.`)
+    Total ${expectedPositiveTotal} positives.
+    Box barcodes scanned:`)
     wrapper = mount(BoxBuster, { localVue })
     await wrapper.setData(data)
     const summary = squish(wrapper.find('caption').text())

--- a/test/pages/box_buster.spec.js
+++ b/test/pages/box_buster.spec.js
@@ -309,7 +309,7 @@ describe('BoxBuster', () => {
   it('checks if the scanned barcodes are duplicates', () => {
     wrapper = mount(BoxBuster, { localVue })
     wrapper.vm.barcodes_scanned = ['12345', '12345', 'barcode']
-    expect(wrapper.vm.isBarcodeDuplicate('12345')).toEqual({ red: true })
-    expect(wrapper.vm.isBarcodeDuplicate('barcode')).toEqual({ red: false })
+    expect(wrapper.vm.isBarcodeDuplicate('12345')).toEqual({ 'text-danger': true })
+    expect(wrapper.vm.isBarcodeDuplicate('barcode')).toEqual({ 'text-danger': false })
   })
 })

--- a/test/pages/box_buster.spec.js
+++ b/test/pages/box_buster.spec.js
@@ -298,5 +298,6 @@ describe('BoxBuster', () => {
     expect(wrapper.vm.barcodes_scanned).toEqual(['12345'])
     expect(wrapper.vm.barcode).toEqual('')
     expect(barcodeField.element.value).toEqual('')
+    expect(wrapper.find('caption').text()).toContain('Box barcodes scanned: 12345')
   })
 })


### PR DESCRIPTION
On box buster after scanning a barcode the input field now reverts to blank to prevent users having to delete barcode each time. List of scanned barcodes added to info field at bottom of table

Closes #53 

Changes proposed in this pull request:

*
*
* ...
