### PR TITLE
Migrate to @babel/eslint-parser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
   },
   parser: 'vue-eslint-parser', // https://eslint.vuejs.org/user-guide/#how-to-use-a-custom-parser
   parserOptions: {
-    parser: 'babel-eslint',
+    parser: '@babel/eslint-parser',
+    requireConfigFile: false,
     sourceType: 'module',
   },
   extends: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,9 @@
       }
     },
     "@babel/eslint-parser": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.0.tgz",
-      "integrity": "sha512-c+AsYOHjI+FgCa+ifLd8sDXp4U4mjkfFgL9NdQWhuA731kAUJs0WdJIXET4A14EJAR9Jv9FFF/MzPWJfV9Oirw==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz",
+      "integrity": "sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==",
       "dev": true,
       "requires": {
         "eslint-scope": "^5.1.1",
@@ -4355,28 +4355,6 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
       "dev": true
-    },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
-      }
     },
     "babel-jest": {
       "version": "27.3.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@babel/core": "^7.13.8",
     "@nuxtjs/axios": "^5.13.1",
     "axios": "^0.24.0",
     "bootstrap": "^4.6.0",
@@ -32,6 +31,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.13.8",
+    "@babel/eslint-parser": "^7.16.3",
     "@babel/preset-env": "^7.13.9",
     "@nuxtjs/dotenv": "^1.4.1",
     "@nuxtjs/eslint-config": "^6.0.0",
@@ -40,7 +40,6 @@
     "@types/pluralize": "^0.0.29",
     "@vue/test-utils": "^1.1.3",
     "babel-core": "^7.0.0-bridge.0",
-    "babel-eslint": "^10.1.0",
     "babel-jest": "^27.3.1",
     "convert-source-map": "^1.7.0",
     "cypress": "^6.6.0",


### PR DESCRIPTION
ES Lint has migrated to the babel mono-repo and some of the dependency updates (specifically eslint-plugin-unicorn) have dropped support for the older parser.