### PR TITLE
DPL-126 removed created_at filter for biosero plate state

### DIFF
--- a/pages/biosero_plate_state.vue
+++ b/pages/biosero_plate_state.vue
@@ -117,7 +117,6 @@ export default {
         { text: 'Run ID', value: 'automation_system_run_id' },
         { text: 'Lab ID', value: 'lab_id' },
         { text: 'Date picked', value: 'date_picked' },
-        { text: 'Date created', value: 'created_at' },
         { text: 'Destination Coordinate', value: 'destination_coordinate' },
       ]
       if (this.plate.source) {

--- a/test/pages/biosero_plate_state.spec.js
+++ b/test/pages/biosero_plate_state.spec.js
@@ -131,7 +131,6 @@ describe('BioseroPlateState', () => {
           { text: 'Run ID', value: 'automation_system_run_id' },
           { text: 'Lab ID', value: 'lab_id' },
           { text: 'Date picked', value: 'date_picked' },
-          { text: 'Date created', value: 'created_at' },
           { text: 'Destination Coordinate', value: 'destination_coordinate' },
           { text: 'Destination Barcode', value: 'destination_barcode' }
         ])
@@ -147,7 +146,6 @@ describe('BioseroPlateState', () => {
           { text: 'Run ID', value: 'automation_system_run_id' },
           { text: 'Lab ID', value: 'lab_id' },
           { text: 'Date picked', value: 'date_picked' },
-          { text: 'Date created', value: 'created_at' },
           { text: 'Destination Coordinate', value: 'destination_coordinate' },
           { text: 'Control Barcode', value: 'control_barcode' },
           { text: 'Control Type', value: 'control' }


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

* Created_at field is not useful to the lab staff so has been removed as a filter
*
* ...
