### PR TITLE
DPL-206: Remove Add to Dart option from UAT Actions

### DIFF
--- a/modules/lighthouse_service.js
+++ b/modules/lighthouse_service.js
@@ -255,12 +255,11 @@ const formatPlateSpecs = (plateSpecs) => {
  * @param {integer} addToDart boolean flag whether run is to be added to DART
  * @returns {object} an object containing success boolean, and response infomation
  */
-const generateTestRun = async (plateSpecs, addToDart) => {
+const generateTestRun = async (plateSpecs) => {
   const plateSpecsParam = formatPlateSpecs(plateSpecs)
   try {
     const body = {
       plate_specs: plateSpecsParam,
-      add_to_dart: addToDart,
     }
     const headers = { headers: { Authorization: config.privateRuntimeConfig.lighthouseApiKey } }
 

--- a/pages/uat_actions/generate_test_run.vue
+++ b/pages/uat_actions/generate_test_run.vue
@@ -63,18 +63,7 @@
           >
         </b-col>
 
-        <b-col>
-          <b-form-checkbox
-            id="addToDart"
-            v-model="addToDart"
-            name="addToDart"
-            value="true"
-            unchecked-value="false"
-            >Add to DART</b-form-checkbox
-          >
-        </b-col>
-
-        <b-col>
+        <b-col cols="6" md="auto">
           <b-button
             id="resetButton"
             v-b-modal.resetModal
@@ -176,7 +165,7 @@ export default {
     },
     async generateTestRun() {
       this.status = statuses.Busy
-      const response = await lighthouse.generateTestRun(this.plateSpecs, this.addToDart)
+      const response = await lighthouse.generateTestRun(this.plateSpecs)
       if (response.success) {
         this.status = statuses.Idle
         this.$router.push({ path: `/uat_actions/test_runs/${response.runId}` })

--- a/pages/uat_actions/test_runs/index.vue
+++ b/pages/uat_actions/test_runs/index.vue
@@ -48,7 +48,7 @@ export default {
   },
   data() {
     return {
-      fields: ['_created', 'status', 'add_to_dart', 'total_plates', 'actions'],
+      fields: ['_created', 'status', 'total_plates', 'actions'],
       perPage: 10,
       currentPage: 1,
       totalRows: 0,

--- a/test/modules/lighthouse_service.spec.js
+++ b/test/modules/lighthouse_service.spec.js
@@ -586,7 +586,7 @@ describe('lighthouse_service api', () => {
   })
 
   describe('#generateTestRun', () => {
-    let runId, plateSpecs, addToDart
+    let runId, plateSpecs
 
     beforeEach(() => {
       jest.spyOn(axios, 'post')
@@ -595,7 +595,6 @@ describe('lighthouse_service api', () => {
         { numberOfPlates: 1, numberOfPositives: 2 },
         { numberOfPlates: 3, numberOfPositives: 4 },
       ]
-      addToDart = true
     })
 
     it('when the request is successful', async () => {
@@ -604,7 +603,7 @@ describe('lighthouse_service api', () => {
       axios.post.mockResolvedValue({
         data: response,
       })
-      const result = await lighthouse.generateTestRun(plateSpecs, addToDart)
+      const result = await lighthouse.generateTestRun(plateSpecs)
 
       const headers = {
         headers: { Authorization: config.privateRuntimeConfig.lighthouseApiKey },
@@ -616,7 +615,6 @@ describe('lighthouse_service api', () => {
           [1, 2],
           [3, 4],
         ],
-        add_to_dart: addToDart,
       }
 
       expect(axios.post).toHaveBeenCalledWith(
@@ -641,7 +639,7 @@ describe('lighthouse_service api', () => {
       }
 
       axios.post.mockImplementationOnce(() => Promise.reject(error))
-      const result = await lighthouse.generateTestRun(plateSpecs, addToDart)
+      const result = await lighthouse.generateTestRun(plateSpecs)
 
       expect(result.success).toBeFalsy()
       expect(result.error).toBe(
@@ -652,7 +650,7 @@ describe('lighthouse_service api', () => {
     it('when the request fails', async () => {
       const error = {}
       axios.post.mockImplementationOnce(() => Promise.reject(error))
-      const result = await lighthouse.generateTestRun(plateSpecs, addToDart)
+      const result = await lighthouse.generateTestRun(plateSpecs)
 
       expect(result.success).toBeFalsy()
       expect(result.error).toBe('An unexpected error has occured')
@@ -667,7 +665,7 @@ describe('lighthouse_service api', () => {
       }
 
       axios.post.mockImplementationOnce(() => Promise.reject(error))
-      const result = await lighthouse.generateTestRun(plateSpecs, addToDart)
+      const result = await lighthouse.generateTestRun(plateSpecs)
 
       expect(result.success).toBeFalsy()
       expect(result.error).toBe('Insertion failure')

--- a/test/pages/uat_actions/generate_test_run.spec.js
+++ b/test/pages/uat_actions/generate_test_run.spec.js
@@ -246,7 +246,6 @@ describe('UAT Actions', () => {
         data() {
           return {
             plateSpecs: [{ numberOfPlates: 1, numberOfPositives: 2 }],
-            addToDart: true,
           }
         },
       })
@@ -262,14 +261,13 @@ describe('UAT Actions', () => {
       await wrapper.find('#generateTestRunButton').trigger('click')
       await flushPromises()
       expect(lighthouse.generateTestRun).toHaveBeenCalledWith(
-        [{ numberOfPlates: 1, numberOfPositives: 2 }],
-        true
+        [{ numberOfPlates: 1, numberOfPositives: 2 }]
       )
       expect(wrapper.vm.$router.push).toHaveBeenCalled()
       expect(wrapper.vm.showAlert).not.toHaveBeenCalled()
     })
 
-    it('when the request failsx', async () => {
+    it('when the request fails', async () => {
       lighthouse.generateTestRun.mockReturnValue({
         success: false,
         error: 'There was an error',
@@ -277,8 +275,7 @@ describe('UAT Actions', () => {
 
       await wrapper.find('#generateTestRunButton').trigger('click')
       expect(lighthouse.generateTestRun).toHaveBeenCalledWith(
-        [{ numberOfPlates: 1, numberOfPositives: 2 }],
-        true
+        [{ numberOfPlates: 1, numberOfPositives: 2 }]
       )
       expect(wrapper.vm.showAlert).toHaveBeenCalledWith('There was an error', 'danger')
     })

--- a/test/pages/uat_actions/test_runs/_id.spec.js
+++ b/test/pages/uat_actions/test_runs/_id.spec.js
@@ -25,7 +25,6 @@ describe('TestRuns.vue', () => {
       _updated_at: '2021-07-12T11:31:15.806Z',
       status: 'completed',
       plate_specs: '[[2,48]]',
-      add_to_dart: false,
       barcodes: '[["TEST-111", "number of positives: 1"],["TEST-222", "number of positives: 2"]]',
     }
 

--- a/test/pages/uat_actions/test_runs/index.spec.js
+++ b/test/pages/uat_actions/test_runs/index.spec.js
@@ -20,7 +20,7 @@ describe('TestRuns.vue', () => {
       lighthouse.getTestRuns.mockResolvedValue({})
     })
     it('will have fields', () => {
-      const expected = ['_created', 'status', 'add_to_dart', 'total_plates', 'actions']
+      const expected = ['_created', 'status', 'total_plates', 'actions']
       expect(wrapper.vm.fields).toEqual(expected)
     })
   })
@@ -36,13 +36,11 @@ describe('TestRuns.vue', () => {
           {
             _id: 1,
             status: 'completed',
-            add_to_dart: true,
             _created_at: '2020-05-13 11:00:00 UTC',
           },
           {
             _id: 2,
             status: 'completed',
-            add_to_dart: true,
             _created_at: '2020-05-13 11:00:00 UTC',
           },
         ],
@@ -72,19 +70,16 @@ describe('TestRuns.vue', () => {
           {
             _id: 111111,
             status: 'completed',
-            add_to_dart: true,
             _created_at: '2020-05-13 11:00:00 UTC',
           },
           {
             _id: 211111,
             status: 'completed',
-            add_to_dart: true,
             _created_at: '2020-05-10 10:00:00 UTC',
           },
           {
             _id: 311111,
             status: 'completed',
-            add_to_dart: true,
             _created_at: '2020-05-10 10:00:00 UTC',
           },
         ],


### PR DESCRIPTION
Changes proposed in this pull request:

* Remove option from the UI.
* Ensure buttons remain right aligned.
* Remove add_to_dart from modules that pass the data to Lighthouse Service.
* Update tests.
