### PR TITLE
Remove Vue dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "jquery": "^3.6.1",
     "nuxt": "^2.15.2",
     "popper.js": "^1.16.1",
-    "vue": "^2.6.12",
     "vue-pluralize": "^0.0.2",
     "vue-template-compiler": "^2.6.12"
   },


### PR DESCRIPTION
I expected more chaos than this small change.  Nuxt is responsible for which version of Vue we are using so we shouldn't have an explicit dependency in the package.json file really.