### PR TITLE
Ensure TODO items are logged as issues

### DIFF
--- a/modules/csv.js
+++ b/modules/csv.js
@@ -1,7 +1,7 @@
 // this is done as lowest common demoninator to get it working
 // nothing fancy, no error checking
 // it will take a file, read it and return it
-// TODO: add some error handling
+// TODO: DPL-561 - add some error handling
 const read = async (file) => {
   const reader = new FileReader()
 

--- a/modules/sprint_general_labels.js
+++ b/modules/sprint_general_labels.js
@@ -5,7 +5,7 @@ import {query, headers} from '@/modules/sprint_constants'
 
 // Will create a new layout object for a print job
 // Requires barcode which will be used for barcode and text field
-// TODO: how do we turn this into external json
+// TODO: DPL-561 - how do we turn this into external json
 const createLayout = ({ barcode, text }) => ({
   barcodeFields: [
     {
@@ -109,7 +109,7 @@ const printDestinationPlateLabels = async ({ numberOfBarcodes, printer }) => {
     const labelFields = createLabelFields({ ...response, text: 'LHTR' })
 
     // print the labels
-    // TODO: similar implementation to printLabels. Can we pass a function?
+    // TODO: DPL-561 - similar implementation to printLabels. Can we pass a function?
     response = await Sprint.printLabels({ labelFields, printer })
 
     if (response.success) {

--- a/modules/sprint_reagent_aliquot_labels.js
+++ b/modules/sprint_reagent_aliquot_labels.js
@@ -4,7 +4,7 @@ import { query, headers } from '@/modules/sprint_constants'
 
 // Will create a new layout object for a print job
 // Requires barcode and two lines of text
-// TODO: how do we turn this into external json
+// TODO: DPL-561 - how do we turn this into external json
 const createLayout = ({ barcode, firstText, secondText }) => ({
   barcodeFields: [
     {

--- a/modules/statuses.js
+++ b/modules/statuses.js
@@ -1,4 +1,4 @@
-// TODO: Think this is an efficient way of doing it but could be improved
+// TODO: DPL-561 - Think this is an efficient way of doing it but could be improved
 // e.g. having a status component
 // building the object and methods dynamically based on string values
 export default {

--- a/pages/print_labels/ad_hoc_plate.vue
+++ b/pages/print_labels/ad_hoc_plate.vue
@@ -6,7 +6,7 @@
         <h1>Print ad hoc plate labels</h1>
         <p class="lead"></p>
 
-        <!-- TODO: better in a component of its own? -->
+        <!-- TODO: GPL-828 - better in a component of its own? -->
         <p>
           <b-alert :show="isError" dismissible variant="danger">
             {{ alertMessage }}
@@ -62,6 +62,7 @@ export default {
     printers: {
       type: Array,
       default() {
+        // TODO: GPL-828 - Can we get this list from SPrint instead of setting it in config
         return config.publicRuntimeConfig.printers.split(',')
       },
     },
@@ -76,7 +77,7 @@ export default {
     }
   },
   computed: {
-    // TODO: abstract and create functions dynamically.
+    // TODO: GPL-828 - abstract and create functions dynamically.
     isIdle() {
       return this.status === statuses.Idle
     },

--- a/pages/print_labels/control_plates.vue
+++ b/pages/print_labels/control_plates.vue
@@ -6,7 +6,7 @@
         <h1>Print Control plate labels</h1>
         <p class="lead"></p>
 
-        <!-- TODO: better in a component of its own? -->
+        <!-- TODO: GPL-828 - better in a component of its own? -->
         <p>
           <b-alert :show="isError" dismissible variant="danger">
             {{ alertMessage }}
@@ -68,6 +68,7 @@ export default {
     printers: {
       type: Array,
       default() {
+        // TODO: GPL-828 - Can we get this list from SPrint instead of setting it in config
         return config.publicRuntimeConfig.printers.split(',')
       },
     },
@@ -82,7 +83,7 @@ export default {
     }
   },
   computed: {
-    // TODO: abstract and create functions dynamically.
+    // TODO: GPL-828 - abstract and create functions dynamically.
     isIdle() {
       return this.status === statuses.Idle
     },

--- a/pages/print_labels/destination_plates.vue
+++ b/pages/print_labels/destination_plates.vue
@@ -6,7 +6,7 @@
         <h1>Print destination plate labels</h1>
         <p class="lead"></p>
 
-        <!-- TODO: better in a component of its own? -->
+        <!-- TODO: GPL-828 - better in a component of its own? -->
         <p>
           <b-alert :show="isError" dismissible variant="danger">
             {{ alertMessage }}
@@ -64,6 +64,7 @@ export default {
     printers: {
       type: Array,
       default() {
+        // TODO: GPL-828 - Can we get this list from SPrint instead of setting it in config
         return config.publicRuntimeConfig.printers.split(',')
       },
     },
@@ -77,7 +78,7 @@ export default {
     }
   },
   computed: {
-    // TODO: abstract and create functions dynamically.
+    // TODO: GPL-828 - abstract and create functions dynamically.
     isIdle() {
       return this.status === statuses.Idle
     },

--- a/pages/print_labels/reagent_aliquots.vue
+++ b/pages/print_labels/reagent_aliquots.vue
@@ -6,7 +6,7 @@
         <h1>Print reagent aliquot labels</h1>
         <p class="lead"></p>
 
-        <!-- TODO: better in a component of its own? -->
+        <!-- TODO: GPL-828 - better in a component of its own? -->
         <p>
           <b-alert :show="isError" dismissible variant="danger">
             {{ alertMessage }}
@@ -79,6 +79,7 @@ export default {
     printers: {
       type: Array,
       default() {
+        // TODO: GPL-828 - Can we get this list from SPrint instead of setting it in config
         return config.publicRuntimeConfig.printers.split(',')
       },
     },
@@ -95,7 +96,7 @@ export default {
     }
   },
   computed: {
-    // TODO: abstract and create functions dynamically.
+    // TODO: GPL-828 - abstract and create functions dynamically.
     isIdle() {
       return this.status === statuses.Idle
     },

--- a/pages/print_labels/source_plates.vue
+++ b/pages/print_labels/source_plates.vue
@@ -6,7 +6,7 @@
         <h1>Print source plate labels</h1>
         <p class="lead"></p>
 
-        <!-- TODO: better in a component of its own? -->
+        <!-- TODO: GPL-828 - better in a component of its own? -->
         <p>
           <b-alert :show="isError" dismissible variant="danger">
             {{ alertMessage }}
@@ -86,6 +86,7 @@ export default {
     printers: {
       type: Array,
       default() {
+        // TODO: GPL-828 - Can we get this list from SPrint instead of setting it in config
         return config.publicRuntimeConfig.printers.split(',')
       },
     },
@@ -99,7 +100,7 @@ export default {
     }
   },
   computed: {
-    // TODO: abstract and create functions dynamically.
+    // TODO: GPL-828 - abstract and create functions dynamically.
     isIdle() {
       return this.status === statuses.Idle
     },

--- a/pages/reports.vue
+++ b/pages/reports.vue
@@ -16,7 +16,7 @@
             Delete Reports
           </b-button>
         </p>
-        <!-- TODO: better in a component of its own? -->
+        <!-- TODO: DPL-561 - better in a component of its own? -->
         <p>
           <b-alert :show="isError" dismissible variant="danger">
             {{ alertMessage }}
@@ -82,7 +82,7 @@ export default {
     reportsToDelete() {
       return this.items.filter((item) => item.selected === true).map((item) => item.filename)
     },
-    // TODO: abstract and create functions dynamically.
+    // TODO: DPL-561 - abstract and create functions dynamically.
     isIdle() {
       return this.status === statuses.Idle
     },

--- a/pages/sentinel_create_samples.vue
+++ b/pages/sentinel_create_samples.vue
@@ -93,7 +93,7 @@ export default {
       this.handleSentinelSampleCreationResponse(resp)
       this.submit_disabled = false
     },
-    // TODO: make this more javascripty? destructuring?
+    // TODO: DPL-561 - make this more javascripty? destructuring?
     handleSentinelSampleCreationResponse(resp) {
       const errored = resp.filter((obj) => Object.keys(obj).includes('errors'))
       const successful = resp.filter((obj) => Object.keys(obj).includes('data'))

--- a/test/modules/sprint_general_labels.spec.js
+++ b/test/modules/sprint_general_labels.spec.js
@@ -6,7 +6,7 @@ import { headers as SprintHeaders } from '@/modules/sprint_constants'
 
 jest.mock('@/modules/baracoda')
 
-// TODO: move out into helper
+// TODO: DPL-561 - move out into helper
 const errorResponse = new Error('There was an error')
 const rejectPromise = () => Promise.reject(errorResponse)
 

--- a/test/modules/sprint_reagent_aliquot_labels.spec.js
+++ b/test/modules/sprint_reagent_aliquot_labels.spec.js
@@ -3,7 +3,7 @@ import PrintLabels, { createLayout, createPrintRequestBody } from '@/modules/spr
 import config from '@/nuxt.config'
 import { headers as SprintHeaders } from '@/modules/sprint_constants'
 
-// TODO: move out into helper
+// TODO: DPL-561 - move out into helper
 const errorResponse = new Error('There was an error')
 const rejectPromise = () => Promise.reject(errorResponse)
 

--- a/test/pages/print_labels/ad_hoc_plate.spec.js
+++ b/test/pages/print_labels/ad_hoc_plate.spec.js
@@ -59,7 +59,7 @@ describe('print control plate labels', () => {
     expect(vm.alertMessage).toBe('Barcodes successfully printed')
   })
 
-  // TODO: These tests are duplicated so will be removed once refactored. Need to get it to pass code coverage.
+  // TODO: GPL-828 - These tests are duplicated so will be removed once refactored. Need to get it to pass code coverage.
   describe('setting the status', () => {
     let vm
 

--- a/test/pages/print_labels/control_plates.spec.js
+++ b/test/pages/print_labels/control_plates.spec.js
@@ -80,7 +80,7 @@ describe('print control plate labels', () => {
     ])
   })
 
-  // TODO: These tests are duplicated so will be removed once refactored. Need to get it to pass code coverage.
+  // TODO: GPL-828 - These tests are duplicated so will be removed once refactored. Need to get it to pass code coverage.
   describe('setting the status', () => {
     let vm
 

--- a/test/pages/print_labels/destination_plates.spec.js
+++ b/test/pages/print_labels/destination_plates.spec.js
@@ -53,7 +53,7 @@ describe('print destination plate labels', () => {
     expect(vm.alertMessage).toBe('Barcodes successfully printed')
   })
 
-  // TODO: These tests are duplicated so will be removed once refactored. Need to get it to pass code coverage.
+  // TODO: GPL-828 - These tests are duplicated so will be removed once refactored. Need to get it to pass code coverage.
   describe('setting the status', () => {
     let vm
 

--- a/test/pages/print_labels/reagent_aliquots.spec.js
+++ b/test/pages/print_labels/reagent_aliquots.spec.js
@@ -135,7 +135,7 @@ describe('print destination plate labels', () => {
     })
   })
 
-  // TODO: These tests are duplicated so will be removed once refactored. Need to get it to pass code coverage.
+  // TODO: GPL-828 - These tests are duplicated so will be removed once refactored. Need to get it to pass code coverage.
   describe('setting the status', () => {
     let vm
 

--- a/test/pages/print_labels/source_labels.spec.js
+++ b/test/pages/print_labels/source_labels.spec.js
@@ -51,7 +51,7 @@ describe('print destination plate labels', () => {
     expect(vm.alertMessage).toBe('Barcodes successfully printed')
   })
 
-  // TODO: the following 3 tests are arbitrary just to get it to pass.
+  // TODO: GPL-828 - the following 3 tests are arbitrary just to get it to pass.
   it('browse files', () => {
     vm.browseFiles()
     expect(true).toBeTruthy()
@@ -61,7 +61,7 @@ describe('print destination plate labels', () => {
     try {
       vm.getFile()
     } catch {
-      // TODO: Implement proper logging of error
+      // TODO: GPL-828 - Implement proper logging of error
       console.log('error')
     }
     expect(true).toBeTruthy()
@@ -72,7 +72,7 @@ describe('print destination plate labels', () => {
     expect(true).toBeTruthy()
   })
 
-  // TODO: These tests are duplicated so will be removed once refactored. Need to get it to pass code coverage.
+  // TODO: GPL-828 - These tests are duplicated so will be removed once refactored. Need to get it to pass code coverage.
   describe('setting the status', () => {
     let vm
 

--- a/test/pages/reports.spec.js
+++ b/test/pages/reports.spec.js
@@ -140,7 +140,7 @@ describe('Index', () => {
     })
   })
 
-  // TODO: Again would be better with an integration test
+  // TODO: DPL-561 - Again would be better with an integration test
   // I also think this the complexity of this test is a bit of a code smell. Defo needs a refactor
   describe('#deleteReports', () => {
     let rows, reportFilenames, lessReportsJson

--- a/test/pages/sentinel_create_samples.spec.js
+++ b/test/pages/sentinel_create_samples.spec.js
@@ -33,7 +33,7 @@ describe('lighthouse sentinel cherrypick', () => {
     expect(wrapper.vm.items).toEqual([])
   })
 
-  // TODO: Are these necessary. Would this be better done in an integration test.
+  // TODO: DPL-561 - Are these necessary. Would this be better done in an integration test.
   describe('submission', () => {
     let button
 


### PR DESCRIPTION
This ensures that there are no TODOs without a ticket associated with them so they won't be missed when considering prioritising these items.
